### PR TITLE
Fix tailwind content path

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: [
     "./*.html",           // 扫描你当前目录的 HTML 文件
-    "./components/**/*.html",
+    "./pages/**/*.html",
     "./node_modules/preline/**/*.js"
   ],
   safelist: [


### PR DESCRIPTION
## Summary
- fix wrong directory in Tailwind config so generated CSS includes templates under `pages/`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684491ae38cc83308b9390c77e750b92