### PR TITLE
Remove unused initialization flag

### DIFF
--- a/assets/js/components/templatesPage.js
+++ b/assets/js/components/templatesPage.js
@@ -13,7 +13,6 @@ function templatesPage() {
     hasMore: true,
     selectedTemplate: null,
     showDetail: false,
-    _initialized: false,
 
     get filteredTemplates() {
       let list = this.templates;


### PR DESCRIPTION
## Summary
- drop `_initialized` flag from templatesPage since it's never used

## Testing
- `grep -R "_initialized" --exclude-dir=node_modules -n`


------
https://chatgpt.com/codex/tasks/task_e_6844a32c8fe08330bc2ddc073bb54512